### PR TITLE
Replace sqlengine with jdbi for TenantTableDao

### DIFF
--- a/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
+++ b/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
@@ -85,7 +85,7 @@ public class TenantTableDao {
   public TenantTable update(final TenantTable tenantTable) {
     LOGGER.trace("update({})", tenantTable);
     return internalJdbi.withHandle(handle -> {
-      int updateCount = handle.createUpdate(
+      final int updateCount = handle.createUpdate(
               "update NODE_TENANT_TABLES set "
                   + "HASH_START = :hashStart, "
                   + "HASH_END = :hashEnd, "

--- a/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
+++ b/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
@@ -62,7 +62,7 @@ public class TenantTableDao {
     LOGGER.trace("create({})", tenantTable);
 
     return internalJdbi.withHandle(handle -> {
-      int updateCount = handle.createUpdate(
+      final int updateCount = handle.createUpdate(
               "insert into NODE_TENANT_TABLES (RID_TENANT,TABLE_NAME,HASH_START,HASH_END, QUANTITY_EST, ENABLED, TABLE_VERSION, KEY, NONCE, PRIMARY_KEY) "
                   + "values (:identifier.tenantId,:identifier.tableName,:hashStart,:hashEnd,:estimatedQuantity,:enabled,:tableVersion,:key,:nonce,:primaryKey)"
           )

--- a/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
+++ b/java/node/src/main/java/com/codeheadsystems/dstore/node/dao/TenantTableDao.java
@@ -16,18 +16,18 @@
 
 package com.codeheadsystems.dstore.node.dao;
 
-import com.codeheadsystems.dstore.node.engine.SqlEngine;
 import com.codeheadsystems.dstore.node.model.ImmutableTenantTable;
-import com.codeheadsystems.dstore.node.model.ImmutableTenantTableIdentifier;
 import com.codeheadsystems.dstore.node.model.TenantTable;
 import com.codeheadsystems.dstore.node.model.TenantTableIdentifier;
-import com.google.common.collect.ImmutableList;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,51 +39,41 @@ public class TenantTableDao {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TenantTableDao.class);
 
-  private final SqlEngine sqlEngine;
+  private final Jdbi internalJdbi;
 
   /**
    * Default constructor.
    *
-   * @param sqlEngine to execute sql.
+   * @param internalJdbi to execute sql.
    */
   @Inject
-  public TenantTableDao(final SqlEngine sqlEngine) {
-    LOGGER.info("TenantDao({})", sqlEngine);
-    this.sqlEngine = sqlEngine;
+  public TenantTableDao(final Jdbi internalJdbi) {
+    LOGGER.info("TenantDao({})", internalJdbi);
+    this.internalJdbi = internalJdbi;
   }
 
   /**
-   * Creates the tenant tablein the database. If it already exists, does nothing but returns the existing tenant.
+   * Creates the tenant table in the database. If it already exists, does nothing but returns the existing tenant.
    *
    * @param tenantTable to create.
    * @return The tenant... either the one that was created or the existing one.
    */
   public TenantTable create(final TenantTable tenantTable) {
     LOGGER.trace("create({})", tenantTable);
-    sqlEngine.executePreparedInternal(
-        "insert into NODE_TENANT_TABLES (RID_TENANT,TABLE_NAME,HASH_START,HASH_END, QUANTITY_EST, ENABLED, TABLE_VERSION, KEY, NONCE, PRIMARY_KEY) values (?,?,?,?,?,?,?,?,?,?)",
-        (ps) -> {
-          try {
-            ps.setString(1, tenantTable.identifier().tenantId());
-            ps.setString(2, tenantTable.identifier().tableName());
-            sqlEngine.setStringField(3, tenantTable.hashStart(), ps);
-            sqlEngine.setStringField(4, tenantTable.hashEnd(), ps);
-            ps.setInt(5, tenantTable.estimatedQuantity());
-            ps.setBoolean(6, tenantTable.enabled());
-            ps.setString(7, tenantTable.tableVersion());
-            ps.setString(8, tenantTable.key());
-            ps.setString(9, tenantTable.nonce());
-            ps.setString(10, tenantTable.primaryKey());
-            ps.execute();
-            if (ps.getUpdateCount() != 1) {
-              throw new IllegalArgumentException("Unable to create tenant table");
-            }
-          } catch (SQLException e) {
-            throw new IllegalArgumentException("Unable to read a tenant table", e);
-          }
-          return null;
-        });
-    return tenantTable;
+
+    return internalJdbi.withHandle(handle -> {
+      int updateCount = handle.createUpdate(
+              "insert into NODE_TENANT_TABLES (RID_TENANT,TABLE_NAME,HASH_START,HASH_END, QUANTITY_EST, ENABLED, TABLE_VERSION, KEY, NONCE, PRIMARY_KEY) "
+                  + "values (:identifier.tenantId,:identifier.tableName,:hashStart,:hashEnd,:estimatedQuantity,:enabled,:tableVersion,:key,:nonce,:primaryKey)"
+          )
+          .bindPojo(tenantTable, TenantTable.class)
+          .execute();
+
+      if (updateCount != 1) {
+        throw new IllegalArgumentException("Unable to create tenant table");
+      }
+      return tenantTable;
+    });
   }
 
   /**
@@ -94,66 +84,34 @@ public class TenantTableDao {
    */
   public TenantTable update(final TenantTable tenantTable) {
     LOGGER.trace("update({})", tenantTable);
-    sqlEngine.executePreparedInternal(
-        "update NODE_TENANT_TABLES set HASH_START = ?, HASH_END = ?, QUANTITY_EST = ?, ENABLED = ?, TABLE_VERSION = ?, PRIMARY_KEY = ? where RID_TENANT = ? and TABLE_NAME = ? and KEY = ? and NONCE = ?",
-        (ps) -> {
-          try {
-            sqlEngine.setStringField(1, tenantTable.hashStart(), ps);
-            sqlEngine.setStringField(2, tenantTable.hashEnd(), ps);
-            ps.setInt(3, tenantTable.estimatedQuantity());
-            ps.setBoolean(4, tenantTable.enabled());
-            ps.setString(5, tenantTable.tableVersion());
-            ps.setString(6, tenantTable.primaryKey());
-            ps.setString(7, tenantTable.identifier().tenantId());
-            ps.setString(8, tenantTable.identifier().tableName());
-            ps.setString(9, tenantTable.key());
-            ps.setString(10, tenantTable.nonce());
-            ps.execute();
-            if (ps.getUpdateCount() == 0) {
-              LOGGER.warn("No entry to update for {}", tenantTable);
-              throw new IllegalArgumentException("No entry to update");
-            } else if (ps.getUpdateCount() > 2) {
-              LOGGER.error("Oops, this is bad. More than one entry updated. {}", tenantTable);
-              throw new IllegalStateException("Multiple entries updated: " + ps.getUpdateCount());
-            }
-          } catch (SQLException e) {
-            throw new IllegalArgumentException("Unable to read a tenant table", e);
-          }
-          return null;
-        });
-    return tenantTable;
+    return internalJdbi.withHandle(handle -> {
+      int updateCount = handle.createUpdate(
+              "update NODE_TENANT_TABLES set "
+                  + "HASH_START = :hashStart, "
+                  + "HASH_END = :hashEnd, "
+                  + "QUANTITY_EST = :estimatedQuantity, "
+                  + "ENABLED = :enabled, "
+                  + "TABLE_VERSION = :tableVersion, "
+                  + "PRIMARY_KEY = :primaryKey "
+                  + "where RID_TENANT = :identifier.tenantId "
+                  + "and TABLE_NAME = :identifier.tableName "
+                  + "and KEY = :key "
+                  + "and NONCE = :nonce "
+          ).bindPojo(tenantTable)
+          .execute();
+      if (updateCount == 0) {
+        LOGGER.warn("No entry to update for {}", tenantTable);
+        throw new IllegalArgumentException("No entry to update");
+      } else if (updateCount > 2) {
+        LOGGER.error("Oops, this is bad. More than one entry updated. {}", tenantTable);
+        throw new IllegalStateException("Multiple entries updated: " + updateCount);
+      }
+      return tenantTable;
+    });
   }
 
   /**
-   * Reads a tenant from the database result set. Does not advance the cursor.
-   *
-   * @param rs result set to read from. Must be on a row.
-   * @return a tenant.
-   */
-  private TenantTable fromResultSet(final ResultSet rs) {
-    try {
-      final TenantTableIdentifier identifier = ImmutableTenantTableIdentifier.builder()
-          .tenantId(rs.getString("RID_TENANT"))
-          .tableName(rs.getString("TABLE_NAME"))
-          .build();
-      return ImmutableTenantTable.builder()
-          .identifier(identifier)
-          .hashStart(Optional.ofNullable(rs.getString("HASH_START")))
-          .hashEnd(Optional.ofNullable(rs.getString("HASH_END")))
-          .estimatedQuantity(rs.getInt("QUANTITY_EST"))
-          .enabled(rs.getBoolean("ENABLED"))
-          .tableVersion(rs.getString("TABLE_VERSION"))
-          .key(rs.getString("KEY"))
-          .nonce(rs.getString("NONCE"))
-          .primaryKey(rs.getString("PRIMARY_KEY"))
-          .build();
-    } catch (SQLException e) {
-      throw new IllegalArgumentException("Unable to read tenant table", e);
-    }
-  }
-
-  /**
-   * Reads from the current database, if the tenant table exists.
+   * Reads from the current database if the tenant table exists.
    *
    * @param tenantId  tenant to read.
    * @param tableName to read.
@@ -161,23 +119,13 @@ public class TenantTableDao {
    */
   public Optional<TenantTable> read(final String tenantId, final String tableName) {
     LOGGER.trace("read({},{})", tenantId, tableName);
-    return sqlEngine.executePreparedInternal(
-        "select * from NODE_TENANT_TABLES where RID_TENANT = ? and TABLE_NAME = ?",
-        (ps) -> {
-          try {
-            ps.setString(1, tenantId);
-            ps.setString(2, tableName);
-            try (final ResultSet rs = ps.executeQuery()) {
-              if (rs.next()) {
-                return Optional.of(fromResultSet(rs));
-              } else {
-                return Optional.empty();
-              }
-            }
-          } catch (SQLException e) {
-            throw new IllegalArgumentException("Unable to read a tenant table", e);
-          }
-        });
+    return internalJdbi.withHandle(handle -> handle
+        .createQuery("select * from NODE_TENANT_TABLES where RID_TENANT = :tenant_id and TABLE_NAME = :table_name")
+        .bind("tenant_id", tenantId)
+        .bind("table_name", tableName)
+        .map(new TenantTableRowMapper())
+        .findOne()
+    );
   }
 
   /**
@@ -188,20 +136,11 @@ public class TenantTableDao {
    */
   public List<String> allTenantTables(final String tenantId) {
     LOGGER.trace("allTenantTables({})", tenantId);
-    return sqlEngine.executePreparedInternal("select TABLE_NAME from NODE_TENANT_TABLES where RID_TENANT = ?", (ps) -> {
-      try {
-        ps.setString(1, tenantId);
-        try (final ResultSet rs = ps.executeQuery()) {
-          final ImmutableList.Builder<String> builder = ImmutableList.builder();
-          while (rs.next()) {
-            builder.add(rs.getString(1));
-          }
-          return builder.build();
-        }
-      } catch (SQLException e) {
-        throw new IllegalArgumentException("Unable to list tenants", e);
-      }
-    });
+    return internalJdbi.withHandle(handle -> handle
+        .createQuery("select TABLE_NAME from NODE_TENANT_TABLES where RID_TENANT = :tenant_id")
+        .bind("tenant_id", tenantId)
+        .mapTo(String.class)
+        .list());
   }
 
   /**
@@ -213,15 +152,31 @@ public class TenantTableDao {
    */
   public boolean delete(final String tenantId, final String tableName) {
     LOGGER.trace("delete({})", tenantId);
-    return sqlEngine.executePreparedInternal("delete from NODE_TENANT_TABLES where RID_TENANT = ? and TABLE_NAME = ?", (ps) -> {
-      try {
-        ps.setString(1, tenantId);
-        ps.setString(2, tableName);
-        ps.execute();
-        return ps.getUpdateCount() > 0;
-      } catch (SQLException e) {
-        throw new IllegalArgumentException("Unable to delete a tenant", e);
-      }
-    });
+    return internalJdbi.withHandle(handle -> handle
+        .createUpdate("delete from NODE_TENANT_TABLES where RID_TENANT = :tenant_id and TABLE_NAME = :table_name")
+        .bind("tenant_id", tenantId)
+        .bind("table_name", tableName)
+        .execute() > 0
+    );
+  }
+
+  private static class TenantTableRowMapper implements RowMapper<TenantTable> {
+
+    @Override
+    public TenantTable map(final ResultSet rs, final StatementContext ctx) throws SQLException {
+      return ImmutableTenantTable.builder()
+          .identifier(TenantTableIdentifier.from(
+              rs.getString("RID_TENANT"),
+              rs.getString("TABLE_NAME")))
+          .hashStart(Optional.ofNullable(rs.getString("HASH_START")))
+          .hashEnd(Optional.ofNullable(rs.getString("HASH_END")))
+          .estimatedQuantity(rs.getInt("QUANTITY_EST"))
+          .enabled(rs.getBoolean("ENABLED"))
+          .tableVersion(rs.getString("TABLE_VERSION"))
+          .key(rs.getString("KEY"))
+          .nonce(rs.getString("NONCE"))
+          .primaryKey(rs.getString("PRIMARY_KEY"))
+          .build();
+    }
   }
 }

--- a/java/node/src/main/java/com/codeheadsystems/dstore/node/module/DataSourceModule.java
+++ b/java/node/src/main/java/com/codeheadsystems/dstore/node/module/DataSourceModule.java
@@ -3,6 +3,8 @@ package com.codeheadsystems.dstore.node.module;
 import com.codeheadsystems.dstore.node.engine.DatabaseEngine;
 import com.codeheadsystems.dstore.node.engine.DatabaseInitializationEngine;
 import com.codeheadsystems.dstore.node.model.Tenant;
+import com.codeheadsystems.dstore.node.model.TenantTable;
+import com.codeheadsystems.dstore.node.model.TenantTableIdentifier;
 import dagger.Module;
 import dagger.Provides;
 import java.sql.Connection;
@@ -13,7 +15,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.immutables.JdbiImmutables;
 
 /**
- * Provides datasources. We pick the database to use here.
+ * Provides data sources. We pick the database to use here.
  */
 @Module(includes = {HsqlDataSourceModule.class})
 public class DataSourceModule {
@@ -55,7 +57,11 @@ public class DataSourceModule {
   @Singleton
   public Jdbi internalJdbi(final DataSource dataSource) {
     final Jdbi jdbi = Jdbi.create(dataSource);
-    jdbi.getConfig(JdbiImmutables.class).registerImmutable(Tenant.class);
+    jdbi.getConfig(JdbiImmutables.class)
+        .registerImmutable(Tenant.class)
+        .registerImmutable(TenantTable.class)
+        .registerImmutable(TenantTableIdentifier.class)
+    ;
     return jdbi;
   }
 }

--- a/java/node/src/test/java/com/codeheadsystems/dstore/node/dao/TenantTableDaoTest.java
+++ b/java/node/src/test/java/com/codeheadsystems/dstore/node/dao/TenantTableDaoTest.java
@@ -72,7 +72,7 @@ class TenantTableDaoTest extends BaseSQLTest {
 
   @BeforeEach
   void setup() {
-    dao = new TenantTableDao(sqlEngine);
+    dao = new TenantTableDao(internalJdbi);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Part of issue #4.

This migration is to remove custom database code and to simplify the dao
 layer.

 A custom row mapper is used because the object doesn't mirror the table
  structurally.  The class is still registered with JDBI so we can use
  it with `bindPojo` though.